### PR TITLE
Setup schemas for users and transactions on Sanity

### DIFF
--- a/.vscode/symbols.json
+++ b/.vscode/symbols.json
@@ -1,1 +1,1 @@
-{"symbols":{},"files":{"client/next-env.d.ts":"2022-08-16T03:34:36.088Z"}}
+{"symbols":{},"files":{"client/next-env.d.ts":"2022-08-16T03:34:36.088Z","client/pages/api/hello.ts":"2022-08-16T00:21:53.000Z"}}

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Project Link: [https://github.com/ehfazrezwan/uniswap-blockchain-app](https://gi
 [issues-shield]: https://img.shields.io/github/issues/ehfazrezwan/uniswap-blockchain-app
 [issues-url]: https://github.com/ehfazrezwan/uniswap-blockchain-app/issues
 [license-shield]: https://img.shields.io/github/license/ehfazrezwan/uniswap-blockchain-app
-[license-url]: https://github.com/ehfazrezwan/uniswap-blockchain-app/blob/master/LICENSE.txt
+[license-url]: https://github.com/ehfazrezwan/uniswap-blockchain-app/blob/master/LICENSE
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=flat-square&logo=linkedin&colorB=555
 [linkedin-url]: https://linkedin.com/in/ehfaz-rezwan
 [product-screenshot]: images/app.png

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -1,16 +1,20 @@
 // First, we must import the schema creator
-import createSchema from 'part:@sanity/base/schema-creator'
+import createSchema from "part:@sanity/base/schema-creator";
 
 // Then import schema types from any plugins that might expose them
-import schemaTypes from 'all:part:@sanity/base/schema-type'
+import schemaTypes from "all:part:@sanity/base/schema-type";
+import { userSchema } from "./userSchema";
+import { transactionSchema } from "./transactionSchema";
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
   // We name our schema
-  name: 'default',
+  name: "default",
   // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     /* Your types here! */
+    transactionSchema,
+    userSchema,
   ]),
-})
+});

--- a/studio/schemas/transactionSchema.js
+++ b/studio/schemas/transactionSchema.js
@@ -1,0 +1,32 @@
+export const transactionSchema = {
+  name: "transactions",
+  title: "Transactions",
+  type: "document",
+  fields: [
+    {
+      name: "txHash",
+      title: "Transaction Hash",
+      type: "string",
+    },
+    {
+      name: "fromAddress",
+      title: "From (Wallet Address)",
+      type: "string",
+    },
+    {
+      name: "toAddress",
+      title: "To (Wallet Address)",
+      type: "string",
+    },
+    {
+      name: "amount",
+      title: "Amount",
+      type: "number",
+    },
+    {
+      name: "timestamp",
+      title: "Timestamp",
+      type: "datetime",
+    },
+  ],
+};

--- a/studio/schemas/userSchema.js
+++ b/studio/schemas/userSchema.js
@@ -1,0 +1,28 @@
+export const userSchema = {
+  name: "users",
+  title: "Users",
+  type: "document",
+  fields: [
+    {
+      name: "address",
+      title: "Wallet Address",
+      type: "string",
+    },
+    {
+      name: "userName",
+      title: "User Name",
+      type: "string",
+    },
+    {
+      name: "transactions",
+      title: "Transactions",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "transactions" }],
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
# Setup schemas for users and transactions on Sanity

### PR Type
Feature

### What does it solve?
Sets up data storage for the application on Sanity.io

### Changes
 - Created schema file `studio/schemas/transactionSchema.js`
 - Created schema file `studio/schemas/userSchema.js`

### How to test
 - Install Sanity CLI via npm `npm install -g @sanity/cli`
 - Setup account on Sanity using `sanity login`
 - Once complete, run `sanity start`
 - You should see confirmation that sanity studio is running locally on port 3333
 - Visiting Sanity studio on `localhost:3333` should display the documents, as shown below:
<img width="1728" alt="Screenshot 2022-09-05 at 4 57 51 PM" src="https://user-images.githubusercontent.com/25001943/188433532-b54f86f8-d2c1-462e-a193-6a5ee568da44.png">

